### PR TITLE
Address memory leaks

### DIFF
--- a/src/exla/exla_nif_util.h
+++ b/src/exla/exla_nif_util.h
@@ -89,6 +89,7 @@ namespace exla {
     void* ptr = enif_alloc_resource(resource_object<T>::type, sizeof(T));
     new(ptr) T(std::move(var));
     ERL_NIF_TERM ret = enif_make_resource(env, ptr);
+    enif_release_resource(ptr);
     return ret;
   }
 
@@ -97,7 +98,9 @@ namespace exla {
     void* ptr = enif_alloc_resource(resource_object<T>::type, sizeof(T));
     T* value = var.release();
     new(ptr) T(std::move(*value));
-    return enif_make_resource(env, ptr);
+    ERL_NIF_TERM ret = enif_make_resource(env, ptr);
+    enif_release_resource(ptr);
+    return ret;
   }
 
   template <typename T>


### PR DESCRIPTION
I'm pretty sure this does it. We call `enif_release_resource` after the object is created and then `free` runs when the resource is garbage collected so I used the `delete` operator to free up that dynamically allocated memory