### PR TITLE
Use a global tensorflow checkout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,6 @@ exla-*.tar
 
 # Ignore build artifacts
 /c_src/exla/erts
+/c_src/tf-*
 /priv/
 /tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,5 @@ exla-*.tar
 
 # Ignore build artifacts
 /c_src/exla/erts
-/c_src/tf-*
 /priv/
 /tmp/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,0 @@
-[submodule "c_src/tensorflow"]
-	path = c_src/tensorflow
-	url = https://github.com/tensorflow/tensorflow.git
-	shallow = true
-	ignore = dirty

--- a/Makefile
+++ b/Makefile
@@ -1,39 +1,65 @@
+# System vars
+HOME ?= $(USERPROFILE)
+TMP ?= $(HOME)/.cache
+
+# mix.exs vars
+# ERTS_INCLUDE_DIR
+# ERTS_VSN
+# EXLA_VSN
+
 # Public configuration
 EXLA_TARGET ?= cpu # can also be cuda
 EXLA_MODE ?= opt # can also be dbg
-EXLA_SO = priv/libexla.so
+EXLA_CACHE ?= $(TMP)/exla
+EXLA_TENSORFLOW_GIT_REPO ?= git@github.com:tensorflow/tensorflow.git
+EXLA_TENSORFLOW_GIT_REV ?= 8a1bb87da5b8dcec1d7f0bf8baa43565c095830e
 
-# Tensorflow flags and config
-ERTS_SYM_DIR = c_src/exla/erts
-TENSORFLOW_DIR = c_src/tensorflow
+# Private configuration
+EXLA_SO = priv/libexla.so
+EXLA_DIR = c_src/exla
+ERTS_SYM_DIR = $(EXLA_DIR)/erts
+BAZEL_FLAGS = --define "framework_shared_object=false" -c $(EXLA_MODE)
+
+TENSORFLOW_NS = tf-$(EXLA_TENSORFLOW_GIT_REV)
+TENSORFLOW_DIR = c_src/$(TENSORFLOW_NS)
 TENSORFLOW_EXLA_NS = tensorflow/compiler/xla/exla
 TENSORFLOW_EXLA_DIR = $(TENSORFLOW_DIR)/$(TENSORFLOW_EXLA_NS)
-BAZEL_FLAGS = --define "framework_shared_object=false" -c $(EXLA_MODE)
+TENSORFLOW_CACHE_DIR = $(EXLA_CACHE)/$(TENSORFLOW_NS)
 
 all: $(EXLA_TARGET)
 
-cpu: $(TENSORFLOW_EXLA_DIR)
-	rm -f $(ERTS_SYM_DIR)
-	ln -s "$(ERTS_INCLUDE_DIR)" $(ERTS_SYM_DIR)
+cpu: symlinks
 	cd $(TENSORFLOW_DIR) && \
 		bazel build $(BAZEL_FLAGS) //$(TENSORFLOW_EXLA_NS):libexla_cpu.so
 	mkdir -p priv
 	cp -f $(TENSORFLOW_DIR)/bazel-bin/$(TENSORFLOW_EXLA_NS)/libexla_cpu.so $(EXLA_SO)
 
-cuda: $(TENSORFLOW_EXLA_DIR)
-	rm -f $(ERTS_SYM_DIR)
-	ln -s "$(ERTS_INCLUDE_DIR)" $(ERTS_SYM_DIR)
+cuda: symlinks
 	cd $(TENSORFLOW_DIR) && \
 		bazel build $(BAZEL_FLAGS) --config=cuda //$(TENSORFLOW_EXLA_NS):libexla_gpu.so
 	mkdir -p priv
 	cp -f $(TENSORFLOW_DIR)/bazel-bin/$(TENSORFLOW_EXLA_NS)/libexla_gpu.so $(EXLA_SO)
 
-$(TENSORFLOW_EXLA_DIR):
-	git submodule init
-	git submodule update
+symlinks: $(TENSORFLOW_DIR)
 	rm -f $(TENSORFLOW_EXLA_DIR)
-	ln -s ../../../../exla $(TENSORFLOW_EXLA_DIR)
+	ln -s "$(PWD)/$(EXLA_DIR)" $(TENSORFLOW_EXLA_DIR)
+	rm -f $(ERTS_SYM_DIR)
+	ln -s "$(ERTS_INCLUDE_DIR)" $(ERTS_SYM_DIR)
+
+# Sets up a tensorflow symlink inside this repo
+$(TENSORFLOW_DIR): $(TENSORFLOW_CACHE_DIR)
+	ln -s "$(TENSORFLOW_CACHE_DIR)" $(TENSORFLOW_DIR)
+
+# Clones tensorflow
+$(TENSORFLOW_CACHE_DIR):
+	mkdir -p $(TENSORFLOW_CACHE_DIR)
+	cd $(TENSORFLOW_CACHE_DIR) && \
+		git init && \
+		git remote add origin $(EXLA_TENSORFLOW_GIT_REPO) && \
+		git fetch --depth 1 origin $(EXLA_TENSORFLOW_GIT_REV) && \
+		git checkout FETCH_HEAD
 
 clean:
-	cd $(TENSORFLOW_DIR) && bazel clean --expunge
-	rm -f $(EXLA_SO)
+	cd $(TENSORFLOW_CACHE_DIR) && bazel clean --expunge
+	rm -f $(ERTS_SYM_DIR) $(TENSORFLOW_EXLA_DIR) $(TENSORFLOW_DIR)
+	rm -rf $(EXLA_SO) $(TENSORFLOW_CACHE_DIR)

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,6 @@ TMP ?= $(HOME)/.cache
 
 # mix.exs vars
 # ERTS_INCLUDE_DIR
-# ERTS_VSN
-# EXLA_VSN
 
 # Public configuration
 EXLA_TARGET ?= cpu # can also be cuda

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ TMP ?= $(HOME)/.cache
 EXLA_TARGET ?= cpu # can also be cuda
 EXLA_MODE ?= opt # can also be dbg
 EXLA_CACHE ?= $(TMP)/exla
-EXLA_TENSORFLOW_GIT_REPO ?= git@github.com:tensorflow/tensorflow.git
+EXLA_TENSORFLOW_GIT_REPO ?= https://github.com/tensorflow/tensorflow.git
 EXLA_TENSORFLOW_GIT_REV ?= 8a1bb87da5b8dcec1d7f0bf8baa43565c095830e
 
 # Private configuration

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 # System vars
-HOME ?= $(USERPROFILE)
-TMP ?= $(HOME)/.cache
+TEMP ?= $(HOME)/.cache
 
 # mix.exs vars
 # ERTS_INCLUDE_DIR
@@ -8,7 +7,7 @@ TMP ?= $(HOME)/.cache
 # Public configuration
 EXLA_TARGET ?= cpu # can also be cuda
 EXLA_MODE ?= opt # can also be dbg
-EXLA_CACHE ?= $(TMP)/exla
+EXLA_CACHE ?= $(TEMP)/exla
 EXLA_TENSORFLOW_GIT_REPO ?= https://github.com/tensorflow/tensorflow.git
 EXLA_TENSORFLOW_GIT_REV ?= 8a1bb87da5b8dcec1d7f0bf8baa43565c095830e
 
@@ -19,10 +18,9 @@ ERTS_SYM_DIR = $(EXLA_DIR)/erts
 BAZEL_FLAGS = --define "framework_shared_object=false" -c $(EXLA_MODE)
 
 TENSORFLOW_NS = tf-$(EXLA_TENSORFLOW_GIT_REV)
-TENSORFLOW_DIR = c_src/$(TENSORFLOW_NS)
+TENSORFLOW_DIR = $(EXLA_CACHE)/$(TENSORFLOW_NS)
 TENSORFLOW_EXLA_NS = tensorflow/compiler/xla/exla
 TENSORFLOW_EXLA_DIR = $(TENSORFLOW_DIR)/$(TENSORFLOW_EXLA_NS)
-TENSORFLOW_CACHE_DIR = $(EXLA_CACHE)/$(TENSORFLOW_NS)
 
 all: $(EXLA_TARGET)
 
@@ -44,20 +42,20 @@ symlinks: $(TENSORFLOW_DIR)
 	rm -f $(ERTS_SYM_DIR)
 	ln -s "$(ERTS_INCLUDE_DIR)" $(ERTS_SYM_DIR)
 
-# Sets up a tensorflow symlink inside this repo
-$(TENSORFLOW_DIR): $(TENSORFLOW_CACHE_DIR)
-	ln -s "$(TENSORFLOW_CACHE_DIR)" $(TENSORFLOW_DIR)
+# Print Tensorflow Dir
+PTD:
+	@ echo $(TENSORFLOW_DIR)
 
 # Clones tensorflow
-$(TENSORFLOW_CACHE_DIR):
-	mkdir -p $(TENSORFLOW_CACHE_DIR)
-	cd $(TENSORFLOW_CACHE_DIR) && \
+$(TENSORFLOW_DIR):
+	mkdir -p $(TENSORFLOW_DIR)
+	cd $(TENSORFLOW_DIR) && \
 		git init && \
 		git remote add origin $(EXLA_TENSORFLOW_GIT_REPO) && \
 		git fetch --depth 1 origin $(EXLA_TENSORFLOW_GIT_REV) && \
 		git checkout FETCH_HEAD
 
 clean:
-	cd $(TENSORFLOW_CACHE_DIR) && bazel clean --expunge
-	rm -f $(ERTS_SYM_DIR) $(TENSORFLOW_EXLA_DIR) $(TENSORFLOW_DIR)
-	rm -rf $(EXLA_SO) $(TENSORFLOW_CACHE_DIR)
+	cd $(TENSORFLOW_DIR) && bazel clean --expunge
+	rm -f $(ERTS_SYM_DIR) $(TENSORFLOW_EXLA_DIR)
+	rm -rf $(EXLA_SO) $(TENSORFLOW_DIR)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Elixir XLA Client for compiling and running Elixir code on CPU/GPU/TPU.
 
 ## Usage
 
-List EXLA as a dependency in your project:
+Add EXLA as a dependency in your project:
 
 ```elixir
 def deps do

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Notice [you will need Bazel installed locally](https://bazel.build/).
 
   * `EXLA_MODE` - controls to compile `opt` (default) artifacts or `dbg`, example: `EXLA_MODE=dbg`
 
+  * `EXLA_CACHE` - control where to store Tensorflow checkouts and builds
+
 ## Building with Docker
 
 The easiest way to build is with [Docker](https://docs.docker.com/get-docker/). You'll also need to set up the [NVIDIA Container Toolkit](https://github.com/NVIDIA/nvidia-docker).
@@ -35,8 +37,8 @@ Then to run (without Cuda):
 docker run -it \
   -v $PWD:$PWD \
   -e TEST_TMPDIR=$PWD/tmp/bazel_cache \
+  -e EXLA_CACHE=$PWD/tmp/exla_cache \
   -w $PWD \
-  --gpus=all \
   --rm exla:cuda10.1 bash
 ```
 
@@ -46,6 +48,7 @@ With Cuda enabled:
 docker run -it \
   -v $PWD:$PWD \
   -e TEST_TMPDIR=$PWD/tmp/bazel_cache \
+  -e EXLA_CACHE=$PWD/tmp/exla_cache \
   -e EXLA_TARGET=cuda \
   -w $PWD \
   --gpus=all \

--- a/README.md
+++ b/README.md
@@ -2,18 +2,27 @@
 
 Elixir XLA Client for compiling and running Elixir code on CPU/GPU/TPU.
 
-## Building locally
+## Usage
 
-EXLA is a regular Elixir project, therefore, to run it locally:
+List EXLA as a dependency in your project:
 
-```shell
-mix deps.get
-mix compile
+```elixir
+def deps do
+  {:exla, "~> 0.1"}
+end
 ```
 
-Notice [you will need Bazel installed locally](https://bazel.build/).
+The first compilation will take a long time, as it needs to compile parts of Tensorflow + XLA. You will need the following installed in your system to compile them:
+
+  * [Git](https://git-scm.com/) for checking out Tensorflow
+  * [Bazel](https://bazel.build/) for compiling Tensorflow
+  * [Python3](https://python.org) with numpy installed (`pip3 install numpy`) for compiling Tensorflow
+
+Subsequent commands should be much faster.
 
 ### Environment variables
+
+You can use the following env vars to customize your build:
 
   * `EXLA_TARGET` - controls to compile with CPU-only (default) or CUDA-enabled, example: `EXLA_TARGET=cuda`
 
@@ -21,7 +30,26 @@ Notice [you will need Bazel installed locally](https://bazel.build/).
 
   * `EXLA_CACHE` - control where to store Tensorflow checkouts and builds
 
-## Building with Docker
+Note those variables can be set directly in the dependency:
+
+```elixir
+def deps do
+  {:exla, "~> 0.1", system_env: %{"EXLA_TARGET" => "CUDA"}}
+end
+```
+
+## Contributing
+
+### Building locally
+
+EXLA is a regular Elixir project, therefore, to run it locally:
+
+```shell
+mix deps.get
+mix test
+```
+
+### Building with Docker
 
 The easiest way to build is with [Docker](https://docs.docker.com/get-docker/). You'll also need to set up the [NVIDIA Container Toolkit](https://github.com/NVIDIA/nvidia-docker).
 
@@ -65,4 +93,10 @@ Or you can run an example:
 
 ```shell
 mix run examples/basic_addition.exs
+```
+
+To run tests:
+
+```shell
+mix test
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -4,11 +4,10 @@ defmodule Exla.MixProject do
   def project do
     [
       app: :exla,
-      version: "0.0.6",
+      version: "0.0.6-dev",
       elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
-      make_args: ["--ignore-errors"],
       compilers: [:elixir_make] ++ Mix.compilers()
     ]
   end


### PR DESCRIPTION
This allows EXLA to share most of the build steps between versions when installed as a package.
