### PR TITLE
Update Dot Product Benchmark

### DIFF
--- a/c_src/exla/exla.cc
+++ b/c_src/exla/exla.cc
@@ -302,19 +302,19 @@ ERL_NIF_TERM constant_r0(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]){
 }
 
 ERL_NIF_TERM constant_r1_fill(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]){
-  if(argc != 2){
+  if(argc != 3){
     return enif_make_badarg(env);
   }
 
-  XLA* xla_objects = (XLA*) enif_priv_data(env);
-
+  xla::XlaBuilder** builder;
   int length, value;
 
-  if(!exla::get(env, argv[0], length)) return enif_make_badarg(env);
-  if(!exla::get(env, argv[1], value)) return enif_make_badarg(env);
+  if(!exla::get<xla::XlaBuilder*>(env, argv[0], builder)) return enif_make_badarg(env);
+  if(!exla::get(env, argv[1], length)) return enif_make_badarg(env);
+  if(!exla::get(env, argv[2], value)) return enif_make_badarg(env);
 
-  xla::XlaOp op = xla::ConstantR1(xla_objects->builder, length, value);
-  return exla::make<xla::XlaOp>(env, op);
+  xla::XlaOp op = xla::ConstantR1(*builder, length, value);
+  return exla::ok(env, exla::make<xla::XlaOp>(env, op));
 }
 
 ERL_NIF_TERM dot(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]){
@@ -328,7 +328,7 @@ ERL_NIF_TERM dot(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]){
   if(!exla::get<xla::XlaOp>(env, argv[1], rhs)) return enif_make_badarg(env);
   // TODO: Handle Precision Configuration
   xla::XlaOp result = xla::Dot(*lhs, *rhs);
-  return exla::make<xla::XlaOp>(env, result);
+  return exla::ok(env, exla::make<xla::XlaOp>(env, result));
 }
 
 /************************ xla::ClientLibrary Functions ***************************/
@@ -581,7 +581,7 @@ static ErlNifFunc exla_funcs[] = {
   {"population_count", 1, population_count},
   /******** Constant Creation Methods *******/
   {"constant_r0", 2, constant_r0},
-  {"constant_r1", 2, constant_r1_fill},
+  {"constant_r1", 3, constant_r1_fill},
   /******** Other XLA Ops *******/
   {"dot", 2, dot},
   /******* Compilation, Execution, Etc. ******/

--- a/lib/exla/nif.ex
+++ b/lib/exla/nif.ex
@@ -154,7 +154,7 @@ defmodule Exla.NIF do
     do: nif_error(__ENV__.function)
 
   def constant_r1(_builder, _length, _value),
-    do: nif_error()
+    do: nif_error(__ENV__.function)
 
   def get_or_create_local_client(_platform, _number_of_replicas, _intra_op_parallelism_threads),
     do: nif_error(__ENV__.function)

--- a/lib/exla/nif.ex
+++ b/lib/exla/nif.ex
@@ -160,7 +160,7 @@ defmodule Exla.NIF do
   def constant_r0(_builder, _value),
     do: nif_error()
 
-  def constant_r1(_length, _value),
+  def constant_r1(_builder, _length, _value),
     do: nif_error()
 
   def get_or_create_local_client(_platform, _number_of_replicas, _intra_op_parallelism_threads),

--- a/lib/exla/op.ex
+++ b/lib/exla/op.ex
@@ -14,6 +14,16 @@ defmodule Exla.Op do
     %Op{builder: builder, ref: ref}
   end
 
+  def constant(%Builder{ref: builder}, value, length) when is_number(value) and is_integer(length) and length >= 0 do
+    {:ok, ref} =  Exla.NIF.constant_r1(builder, value, length)
+    %Op{builder: builder, ref: ref}
+  end
+
+  def dot(%Op{builder: builder, ref: left}, %Op{builder: builder, ref: right}) do
+    {:ok, ref} = Exla.NIF.dot(left, right)
+    %Op{builder: builder, ref: ref}
+  end
+
   def parameter(%Builder{ref: builder}, i, %Shape{ref: shape}, name)
       when is_integer(i) and i >= 0 and is_binary(name) do
     {:ok, ref} = Exla.NIF.parameter(builder, i, shape, name)


### PR DESCRIPTION
I just wanted to see....
```
Operating System: Linux
CPU Information: AMD Ryzen 5 3600 6-Core Processor
Number of Available Cores: 12
Available memory: 31.35 GB
Elixir 1.11.2
Erlang 23.1

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 10 s
memory time: 2 s
parallel: 1
inputs: none specified
Estimated total run time: 28 s

Benchmarking elixir dot...
Benchmarking xla dot...

Name                 ips        average  deviation         median         99th %
xla dot          17.39 K      0.0575 ms   ±693.57%      0.0380 ms      0.0868 ms
elixir dot     0.00158 K      634.70 ms    ±34.47%      591.34 ms     1301.42 ms

Comparison: 
xla dot          17.39 K
elixir dot     0.00158 K - 11039.23x slower +634.64 ms

Memory usage statistics:

Name          Memory usage
xla dot         0.00068 MB
elixir dot       381.47 MB - 561797.58x memory usage +381.47 MB

**All measurements for memory usage were the same**
```