### PR TITLE
Zero-Copy Transfers

### DIFF
--- a/c_src/exla/BUILD
+++ b/c_src/exla/BUILD
@@ -5,9 +5,10 @@ package(default_visibility=["//visibility:private"])
 cc_library(
   name = "exla_allocator",
   srcs = ["exla_allocator.cc"],
-  hdrs = ["exla_allocator.h"],
+  hdrs = ["exla_allocator.h"] + glob(["erts/**/*.h"]),
   deps = [
-    "@org_tensorflow//tensorflow/stream_executor:stream_executor_headers",
+    "@org_tensorflow//tensorflow/core/framework:allocator",
+    "@org_tensorflow//tensorflow/core:lib",
     "@org_tensorflow//tensorflow/compiler/xla:statusor",
   ],
 )
@@ -35,9 +36,11 @@ cc_library (
 cc_library(
   name = "exla_client",
   srcs = ["exla_client.cc"],
-  hdrs = ["exla_client.h"],
+  hdrs = ["exla_client.h"] + glob(["erts/**/*.h"]),
   deps = [
     ":exla_device",
+    ":exla_allocator",
+    "@org_tensorflow//tensorflow/compiler/xla:cpu_function_runtime",
     "@org_tensorflow//tensorflow/compiler/xla/client:client_library",
     "@org_tensorflow//tensorflow/compiler/xla/service/gpu:gpu_executable_run_options",
     "@org_tensorflow//tensorflow/core:lib",

--- a/c_src/exla/BUILD
+++ b/c_src/exla/BUILD
@@ -40,6 +40,7 @@ cc_library(
   deps = [
     ":exla_device",
     ":exla_allocator",
+    ":exla_executable",
     "@org_tensorflow//tensorflow/compiler/xla:cpu_function_runtime",
     "@org_tensorflow//tensorflow/compiler/xla/client:client_library",
     "@org_tensorflow//tensorflow/compiler/xla/service/gpu:gpu_executable_run_options",

--- a/c_src/exla/BUILD
+++ b/c_src/exla/BUILD
@@ -40,7 +40,6 @@ cc_library(
   deps = [
     ":exla_device",
     ":exla_allocator",
-    ":exla_executable",
     "@org_tensorflow//tensorflow/compiler/xla:cpu_function_runtime",
     "@org_tensorflow//tensorflow/compiler/xla/client:client_library",
     "@org_tensorflow//tensorflow/compiler/xla/service/gpu:gpu_executable_run_options",

--- a/c_src/exla/exla.cc
+++ b/c_src/exla/exla.cc
@@ -111,6 +111,14 @@ ERL_NIF_TERM binary_to_shaped_buffer(ErlNifEnv* env, int argc, const ERL_NIF_TER
   if(!exla::get<xla::Shape>(env, argv[2], shape)) return enif_make_badarg(env);
   if(!exla::get(env, argv[3], device_ordinal)) return enif_make_badarg(env);
 
+  // Temporary to test BufferFromErlBin
+  exla::ExlaDevice* device = (*client)->device(device_ordinal);
+  if(device->executor()->platform()->id() == stream_executor::host::kHostPlatformId) {
+    EXLA_ASSIGN_OR_RETURN(std::unique_ptr<xla::ScopedShapedBuffer> buffer, (*client)->BufferFromErlBin(bin, *shape, device), env);
+    xla::ScopedShapedBuffer* buffer_ = buffer.release();
+    return exla::ok(env, exla::make<xla::ShapedBuffer>(env, *buffer_));
+  }
+
   stream_executor::DeviceMemoryAllocator* allocator = (*client)->allocator();
 
   const char *data_ptr = (char *) bin.data;

--- a/c_src/exla/exla.cc
+++ b/c_src/exla/exla.cc
@@ -111,24 +111,10 @@ ERL_NIF_TERM binary_to_shaped_buffer(ErlNifEnv* env, int argc, const ERL_NIF_TER
   if(!exla::get<xla::Shape>(env, argv[2], shape)) return enif_make_badarg(env);
   if(!exla::get(env, argv[3], device_ordinal)) return enif_make_badarg(env);
 
-  // Temporary to test BufferFromErlBin
   exla::ExlaDevice* device = (*client)->device(device_ordinal);
-  if(device->executor()->platform()->id() == stream_executor::host::kHostPlatformId) {
-    EXLA_ASSIGN_OR_RETURN(std::unique_ptr<xla::ScopedShapedBuffer> buffer, (*client)->BufferFromErlBin(bin, *shape, device), env);
-    xla::ScopedShapedBuffer* buffer_ = buffer.release();
-    return exla::ok(env, exla::make<xla::ShapedBuffer>(env, *buffer_));
-  }
-
-  stream_executor::DeviceMemoryAllocator* allocator = (*client)->allocator();
-
-  const char *data_ptr = (char *) bin.data;
-  int64_t data_size = bin.size;
-
-  xla::BorrowingLiteral literal = xla::BorrowingLiteral(const_cast<char *>(data_ptr), *shape);
-
-  EXLA_ASSIGN_OR_RETURN(auto scoped_buffer, (*client)->client()->LiteralToShapedBuffer(literal, device_ordinal, allocator), env);
-
-  return exla::ok(env, exla::make<xla::ShapedBuffer>(env, scoped_buffer));
+  EXLA_ASSIGN_OR_RETURN(std::unique_ptr<xla::ScopedShapedBuffer> buffer, (*client)->BufferFromErlBin(bin, *shape, device), env);
+  xla::ScopedShapedBuffer* buffer_ = buffer.release();
+  return exla::ok(env, exla::make<xla::ShapedBuffer>(env, *buffer_));
 }
 
 ERL_NIF_TERM shaped_buffer_to_binary(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]){

--- a/c_src/exla/exla_allocator.cc
+++ b/c_src/exla/exla_allocator.cc
@@ -1,41 +1,5 @@
 #include "tensorflow/compiler/xla/exla/exla_allocator.h"
 
-namespace xla {
+namespace exla {
 
-  ExlaAllocator::ExlaAllocator(se::Platform* platform)
-      : se::DeviceMemoryAllocator(platform) {}
-
-  ExlaAllocator::~ExlaAllocator() {
-    if (!allocations_.empty()) {
-      LOG(FATAL) << "Some allocations not freed!";
-    }
-  }
-
-  StatusOr<se::OwningDeviceMemory> ExlaAllocator::Allocate(int device_ordinal, uint64 size,
-                                            bool /*retry_on_failure*/,
-                                            int64 /*memory_space*/){
-    // By contract, we must return null if size == 0.
-    if (size == 0) {
-      return se::OwningDeviceMemory();
-    }
-    void *buf = malloc(size);
-    allocations_.insert({device_ordinal, buf});
-    return se::OwningDeviceMemory(se::DeviceMemoryBase(buf, size),
-                                  device_ordinal, this);
-  }
-
-  Status ExlaAllocator::Deallocate(int device_ordinal, se::DeviceMemoryBase mem){
-    if (mem.is_null()) {
-      return Status::OK();
-    }
-
-    auto it = allocations_.find({device_ordinal, mem.opaque()});
-    if (it == allocations_.end()) {
-      LOG(FATAL) << "Allocation not found (double free?)";
-    } else {
-      free(mem.opaque());
-      allocations_.erase(it);
-    }
-    return Status::OK();
-  }
-} // namespace xla
+} // namespace exla

--- a/c_src/exla/exla_client.cc
+++ b/c_src/exla/exla_client.cc
@@ -1,4 +1,5 @@
 #include "tensorflow/compiler/xla/exla/exla_client.h"
+#include "tensorflow/compiler/xla/cpu_function_runtime.h"
 #include "tensorflow/compiler/xla/exla/exla_allocator.h"
 #include "tensorflow/core/common_runtime/gpu/gpu_host_allocator.h"
 #include "tensorflow/core/common_runtime/gpu/gpu_mem_allocator.h"
@@ -8,6 +9,8 @@
 #include "absl/memory/memory.h"
 
 namespace exla {
+
+  using int64 = tensorflow::int64;
 
   ExlaClient::ExlaClient(xla::LocalClient* client,
                          int host_id,
@@ -30,6 +33,51 @@ namespace exla {
       host_memory_allocator_ = std::make_unique<ExlaErtsAllocator>();
     }
 
+  }
+
+  xla::StatusOr<std::unique_ptr<xla::ScopedShapedBuffer>> ExlaClient::BufferFromErlBin(const ErlNifBinary bin,
+                                                                                       const xla::Shape& shape,
+                                                                                       ExlaDevice* device) {
+    // Get the expected size of the given shape
+    int64 size = xla::ShapeUtil::ByteSizeOf(shape);
+    // Validate the expected size and actual data size are the same
+    // If they are not, we need to return an error because otherwise we'll be trying to read
+    // from invalid memory
+    if(size != bin.size) {
+      return tensorflow::errors::InvalidArgument("Expected %d bytes from binary but got %d.", size, bin.size);
+    }
+    // Transfer Manager will manager the "transfer" to the device
+    xla::TransferManager* transfer_manager = client()->backend().transfer_manager();
+    // Ask for shape which has a compact layout on the device, in other words the anticipated shape of the data
+    // on the device
+    // TODO: Handle StatusOr
+    xla::Shape compact_shape = transfer_manager->ChooseCompactLayoutForShape(shape).ConsumeValueOrDie();
+    // CPU Platform allows for zero-copy transfers, we can just read directly from the binary
+    bool is_cpu_platform = device->executor()->platform()->id() == se::host::kHostPlatformId;
+
+    if(is_cpu_platform) {
+      // Validates that the data is sufficiently aligned for a zero-copy transfer
+      // XLA enforces a 16-byte alignment
+      bool can_use_zero_copy = (absl::bit_cast<std::uintptr_t>(bin.data) & (xla::cpu_function_runtime::kMinAlign - 1)) == 0;
+      // Ensure the shapes match, I think this avoids illegal memory errors
+      if(shape.layout() == compact_shape.layout()) {
+        se::DeviceMemoryBase buffer;
+
+        if(can_use_zero_copy) {
+          // Point directly to binary data!
+          buffer = se::DeviceMemoryBase(const_cast<unsigned char*>(bin.data), size);
+        } else {
+          // Otherwise we stage on the VM and copy between
+          void* staging_buffer = host_memory_allocator()->AllocateRaw(xla::cpu_function_runtime::kMinAlign, size);
+          buffer = se::DeviceMemoryBase(staging_buffer, size);
+          std::memcpy(staging_buffer, bin.data, size);
+        }
+        auto device_buffer = absl::make_unique<xla::ScopedShapedBuffer>(compact_shape, allocator(), device->id());
+        auto memory = se::OwningDeviceMemory(buffer, device->id(), allocator());
+        device_buffer->set_buffer(std::move(memory), {});
+        return std::move(device_buffer);
+      }
+    }
   }
 
   xla::StatusOr<ExlaClient*> GetCpuClient(int num_replicas, int intra_op_parallelism_threads) {

--- a/c_src/exla/exla_client.cc
+++ b/c_src/exla/exla_client.cc
@@ -1,4 +1,5 @@
 #include "tensorflow/compiler/xla/exla/exla_client.h"
+#include "tensorflow/compiler/xla/exla/exla_allocator.h"
 #include "tensorflow/core/common_runtime/gpu/gpu_host_allocator.h"
 #include "tensorflow/core/common_runtime/gpu/gpu_mem_allocator.h"
 #include "tensorflow/core/common_runtime/gpu/gpu_bfc_allocator.h"
@@ -7,22 +8,6 @@
 #include "absl/memory/memory.h"
 
 namespace exla {
-
-  // See: https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/xla/pjrt/pjrt_client.cc#L171-L183
-  // TODO: Move to `exla_allocator.h` and consider implementation details
-  class CpuAllocator : public tensorflow::Allocator {
-  public:
-    CpuAllocator() = default;
-
-    std::string Name() override { return "cpu"; }
-
-    void* AllocateRaw(size_t alignment, size_t num_bytes) override {
-      return tensorflow::port::AlignedMalloc(num_bytes, alignment);
-    }
-    void DeallocateRaw(void* ptr) override {
-      return tensorflow::port::AlignedFree(ptr);
-    }
-  };
 
   ExlaClient::ExlaClient(xla::LocalClient* client,
                          int host_id,
@@ -42,7 +27,7 @@ namespace exla {
     }
 
     if(!host_memory_allocator) {
-      host_memory_allocator_ = std::make_unique<CpuAllocator>();
+      host_memory_allocator_ = std::make_unique<ExlaErtsAllocator>();
     }
 
   }

--- a/c_src/exla/exla_client.h
+++ b/c_src/exla/exla_client.h
@@ -33,6 +33,8 @@ namespace exla {
 
     virtual ~ExlaClient() = default;
 
+    xla::StatusOr<std::unique_ptr<xla::ScopedShapedBuffer>> BufferFromBinaryData();
+
     xla::LocalClient* client() { return client_; }
 
     tensorflow::Allocator* host_memory_allocator() { return host_memory_allocator_.get(); }

--- a/c_src/exla/exla_client.h
+++ b/c_src/exla/exla_client.h
@@ -2,6 +2,7 @@
 #define EXLA_CLIENT_H_
 
 #include "tensorflow/compiler/xla/exla/exla_device.h"
+#include "tensorflow/compiler/xla/exla/erts/erl_nif.h"
 
 #include "tensorflow/compiler/xla/client/client_library.h"
 #include "tensorflow/compiler/xla/service/platform_util.h"
@@ -33,8 +34,9 @@ namespace exla {
 
     virtual ~ExlaClient() = default;
 
-    xla::StatusOr<std::unique_ptr<xla::ScopedShapedBuffer>> BufferFromBinaryData();
-
+    xla::StatusOr<std::unique_ptr<xla::ScopedShapedBuffer>> BufferFromErlBin(const ErlNifBinary binary,
+                                                                             const xla::Shape& shape,
+                                                                             ExlaDevice* device);
     xla::LocalClient* client() { return client_; }
 
     tensorflow::Allocator* host_memory_allocator() { return host_memory_allocator_.get(); }

--- a/c_src/exla/exla_client.h
+++ b/c_src/exla/exla_client.h
@@ -37,6 +37,7 @@ namespace exla {
     xla::StatusOr<std::unique_ptr<xla::ScopedShapedBuffer>> BufferFromErlBin(const ErlNifBinary binary,
                                                                              const xla::Shape& shape,
                                                                              ExlaDevice* device);
+
     xla::LocalClient* client() { return client_; }
 
     tensorflow::Allocator* host_memory_allocator() { return host_memory_allocator_.get(); }

--- a/c_src/exla/exla_device.cc
+++ b/c_src/exla/exla_device.cc
@@ -10,9 +10,11 @@ namespace exla {
     compute_stream_ = absl::make_unique<se::Stream>(executor);
     host_to_device_stream_ = absl::make_unique<se::Stream>(executor);
     callback_stream_ = absl::make_unique<se::Stream>(executor);
+    device_to_host_stream_ = absl::make_unique<se::Stream>(executor);
     compute_stream_->Init();
     host_to_device_stream_->Init();
     callback_stream_->Init();
+    device_to_host_stream_->Init();
   }
 
 }

--- a/c_src/exla/exla_device.h
+++ b/c_src/exla/exla_device.h
@@ -30,6 +30,9 @@ namespace exla {
 
     se::Stream* host_to_device_stream() const { return host_to_device_stream_.get(); }
 
+    // TODO: Make multiple of these
+    se::Stream* device_to_host_stream() const { return device_to_host_stream_.get(); }
+
     se::Stream* callback_stream() const { return callback_stream_.get(); }
 
   private:
@@ -38,6 +41,7 @@ namespace exla {
     xla::LocalClient* const client_;
     std::unique_ptr<se::Stream> compute_stream_;
     std::unique_ptr<se::Stream> host_to_device_stream_;
+    std::unique_ptr<se::Stream> device_to_host_stream_;
     std::unique_ptr<se::Stream> callback_stream_;
   };
 }

--- a/c_src/exla/exla_nif_util.cc
+++ b/c_src/exla/exla_nif_util.cc
@@ -157,6 +157,10 @@ namespace exla {
     return 1;
   }
 
+  ERL_NIF_TERM make(ErlNifEnv* env, ErlNifBinary &var) {
+    return enif_make_binary(env, &var);
+  }
+
   ERL_NIF_TERM make(ErlNifEnv* env, int &var) { return enif_make_int(env, var); }
   ERL_NIF_TERM make(ErlNifEnv* env, std::string &var){ return enif_make_string(env, var.c_str(), ERL_NIF_LATIN1); }
   ERL_NIF_TERM make(ErlNifEnv* env, const char* string){ return enif_make_string(env, string, ERL_NIF_LATIN1); }

--- a/c_src/exla/exla_nif_util.h
+++ b/c_src/exla/exla_nif_util.h
@@ -52,7 +52,7 @@ namespace exla {
    */
   ERL_NIF_TERM make(ErlNifEnv* env, int &var);
   ERL_NIF_TERM make(ErlNifEnv* env, std::string &var);
-
+  ERL_NIF_TERM make(ErlNifEnv* env, ErlNifBinary &var);
   ERL_NIF_TERM make(ErlNifEnv* env, const char* string);
 
   /*

--- a/c_src/exla/exla_nif_util.h
+++ b/c_src/exla/exla_nif_util.h
@@ -2,7 +2,6 @@
 #define EXLA_NIF_UTIL_H_
 
 #include "tensorflow/compiler/xla/exla/erts/erl_nif.h"
-#include "tensorflow/compiler/xla/exla/exla_allocator.h"
 
 #include "absl/types/span.h"
 

--- a/lib/exla/local_executable.ex
+++ b/lib/exla/local_executable.ex
@@ -67,11 +67,8 @@ defmodule Exla.LocalExecutable do
     # This is the same as OneFlow's XLA Executable Context, but we do some work in Elixir
     with {:ok, {_platform, ordinal}} <- Client.check_device_compatibility(client, device),
          {:ok, inputs} <- populate_input_buffers(client, arguments, device),
-         {:ok, ref} <- Exla.NIF.run(client.ref, exec, inputs, ordinal, run_id, rng_seed, launch_id),
-         # TODO: Replace this with something similar to `populate_output_buffers`
-         # TODO: We can set the result layout during compilation, maybe we can use that here.
-         {:ok, shape} <- Exla.NIF.on_host_shape(ref) do
-      %Tensor{data: {:ref, ref}, shape: %Shape{ref: shape}, device: device}
+         {:ok, ref} <- Exla.NIF.run(client.ref, exec, inputs, ordinal, run_id, rng_seed, launch_id) do
+      %Tensor{data: {:ref, ref}, shape: %Shape{ref: nil}, device: device}
     end
   end
 end

--- a/lib/exla/local_executable.ex
+++ b/lib/exla/local_executable.ex
@@ -64,10 +64,13 @@ defmodule Exla.LocalExecutable do
     # Launch ID used to coordinate multi-device launches.
     # See: https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/xla/pjrt/pjrt_client.h#L752-L755
     launch_id = Keyword.get(options, :launch_id, 0)
+    # Whether to keep result on device
+    keep_on_device = Keyword.get(options, :keep_on_device, true)
+    keep_on_device_int = if keep_on_device, do: 1, else: 0
     # This is the same as OneFlow's XLA Executable Context, but we do some work in Elixir
     with {:ok, {_platform, ordinal}} <- Client.check_device_compatibility(client, device),
          {:ok, inputs} <- populate_input_buffers(client, arguments, device),
-         {:ok, ref} <- Exla.NIF.run(client.ref, exec, inputs, ordinal, run_id, rng_seed, launch_id) do
+         {:ok, ref} <- Exla.NIF.run(client.ref, exec, inputs, ordinal, run_id, rng_seed, launch_id, keep_on_device_int) do
       %Tensor{data: {:ref, ref}, shape: %Shape{ref: nil}, device: device}
     end
   end

--- a/lib/exla/local_executable.ex
+++ b/lib/exla/local_executable.ex
@@ -65,7 +65,7 @@ defmodule Exla.LocalExecutable do
     # See: https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/xla/pjrt/pjrt_client.h#L752-L755
     launch_id = Keyword.get(options, :launch_id, 0)
     # Whether to keep result on device
-    keep_on_device = Keyword.get(options, :keep_on_device, true)
+    keep_on_device = Keyword.get(options, :keep_on_device, false)
     keep_on_device_int = if keep_on_device, do: 1, else: 0
     # This is the same as OneFlow's XLA Executable Context, but we do some work in Elixir
     with {:ok, {_platform, ordinal}} <- Client.check_device_compatibility(client, device),

--- a/lib/exla/nif.ex
+++ b/lib/exla/nif.ex
@@ -192,7 +192,7 @@ defmodule Exla.NIF do
   def compile(_client, _computation, _argument_layouts, _device_ordinal, _num_replicas, _num_partitions),
     do: nif_error(__ENV__.function)
 
-  def run(_client, _executable, _arguments, _device_ordinal, _run_id, _rng_seed, _launch_id),
+  def run(_client, _executable, _arguments, _device_ordinal, _run_id, _rng_seed, _launch_id, _keep_on_device),
     do: nif_error(__ENV__.function)
 
   def literal_to_shaped_buffer(_client, _literal, _device_ordinal),

--- a/test/exla/local_executable_test.exs
+++ b/test/exla/local_executable_test.exs
@@ -69,7 +69,8 @@ defmodule LocalExecutableTest do
     res = Op.add(x, y)
     comp = Builder.build(res)
     exec = Client.compile(state[:cpu], comp, {t1.shape, t2.shape})
-    assert %Tensor{data: {:ref, _}, shape: %Shape{}} = LocalExecutable.run(exec, {t1, t2})
+    # TODO: Change the API to be agnostic of endianess
+    assert %Tensor{data: {:ref, <<2, 0, 0, 0>>}, shape: %Shape{}} = LocalExecutable.run(exec, {t1, t2})
   end
 
   test "slice", state do


### PR DESCRIPTION
Only optimized on CPU right now, benchmark showing virtually no difference between "pre-loaded" and not pre-loaded:

```
Name                             ips        average  deviation         median         99th %
xla cpu dot pre-loaded        2.58 K      387.98 μs    ±11.64%      380.02 μs      618.88 μs
xla cpu dot                   2.51 K      398.85 μs    ±12.73%      388.67 μs      633.52 μs
elixir dot                  0.0235 K    42494.06 μs    ±20.26%    41933.57 μs    61825.09 μs

Comparison: 
xla cpu dot pre-loaded        2.58 K
xla cpu dot                   2.51 K - 1.03x slower +10.87 μs
elixir dot                  0.0235 K - 109.53x slower +42106.08 μs
```